### PR TITLE
Open Repository in Default Browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,32 @@ All notable changes to the "vscode-ghq" extension will be documented in this fil
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [Unreleased]
+### Added
+- `extension.ghqOpenInBrowser` : Open Repository in Default Browser
+
+## [0.4.1] - 2018-08-16
+
+### Fixed
+- Fix an issue that URI creation on Windows didn't work
+- Remove empty line from `ghq list` output
+
+## [0.4.0] - 2018-08-05
+
+### Added
+- `extension.ghqAddToWorkSpace` : Add Repository to Current Workspace
+
+## [0.3.0] - 2016-12-26
+
+### Added
+- `extension.ghqOpenInNewWindow` : Open Repository in New Window
+
+### Changed
+- Rename `extension.ghqMove` to `extension.ghqOpen`
+
+## [0.2.0] - 2016-12-24
+
+### Added
 - Initial release
+- `extension.ghqMove` : Move to repository
+- `extension.ghqGet` : Get Repository
+

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "onCommand:extension.ghqOpen",
     "onCommand:extension.ghqOpenInNewWindow",
     "onCommand:extension.ghqAddToWorkSpace",
+    "onCommand:extension.ghqOpenInBrowser",
     "onCommand:extension.ghqGet"
   ],
   "main": "./out/src/extension",
@@ -42,6 +43,11 @@
       {
         "command": "extension.ghqAddToWorkSpace",
         "title": "Add Repository to Current Workspace",
+        "category": "GHQ"
+      },
+      {
+        "command": "extension.ghqOpenInBrowser",
+        "title": "Open Repository Page in Default Browser",
         "category": "GHQ"
       },
       {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.commands.registerCommand('extension.ghqOpen', ghqOpen));
     context.subscriptions.push(vscode.commands.registerCommand('extension.ghqOpenInNewWindow', ghqOpenInNewWindow));
     context.subscriptions.push(vscode.commands.registerCommand('extension.ghqAddToWorkSpace', ghqAddToWorkSpace));
+    context.subscriptions.push(vscode.commands.registerCommand('extension.ghqOpenInBrowser', ghqOpenInBrowser));
 }
 
 export function deactivate() {
@@ -37,6 +38,13 @@ async function ghqAddToWorkSpace(){
     const uri = await ghqListRepositoryAndPick();
     const position = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders.length : 0;
     if(uri) vscode.workspace.updateWorkspaceFolders(position, null, { uri });
+}
+
+async function ghqOpenInBrowser(){
+    const uri = await ghqListRepositoryAndPick();
+    if(!uri) return;
+    const webUri = 'https://' + uri.path.split('/').slice(-3).join('/'); // https://${host}/${user|org}/${repo}
+    vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(webUri));
 }
 
 async function ghqGetRepositoryList() {


### PR DESCRIPTION
度々失礼します。

選択したリポジトリのWebページをブラウザで開く`extension.ghqOpenInBrowser`コマンドを追加しました。
`https://${host}/${user|org}/${repo}`の形式であれば、GitHub以外でも対応可能です。

また、簡単ではありますがCHANGELOGを書いてみました。
ご確認よろしくお願い致します。