### PR TITLE
Fix the way of getting stdout of child_process.exec

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,7 +48,7 @@ async function ghqOpenInBrowser(){
 }
 
 async function ghqGetRepositoryList() {
-    const stdout = await promisify(childProcess.exec)('ghq list').catch(err => {
+    const { stdout } = await promisify(childProcess.exec)('ghq list').catch(err => {
         vscode.window.showInformationMessage(err.name + ': ' + err.message);
         return '';
     });


### PR DESCRIPTION
I'm huge fan of this extention !
I'm new to OSS contribution and English isn't my native language.
So if you hard to understand what I'm saying, I would like to rewrite this comment in Japanese.

## Problem

Now I have an error like following when I use `extension.ghqOpen` or `extension.ghqOpenInNewWindow`.

```
stdout.split is not a function
```
And after vscode shows this message, nothing happens any more.

## From when?

I noticed it today.
But I don't know when this extension was updated.

## Solution

I degugged and found that it occurs when apply `split` to the stdout of `child_process.exec`.
When `child_process.exec` resolved, it returns an object containing `error` , `stdout` , `stdin`.
https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback
So I change to not applying `split` method direct to returned value but applying to value of `stdout` key in returned object. 