### PR TITLE
fix a problem that repos located in non-primary ghq.root cannot be opened

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,12 +61,13 @@ async function ghqListRepositoryAndPick() {
         return;
     }
 
-    const ghqRoot = childProcess.execSync('ghq root').toString().trim();
     const ghqReposList = await ghqGetRepositoryList();
     const selectedRepository = await vscode.window.showQuickPick(ghqReposList);
     if (selectedRepository === undefined || selectedRepository === '') return '';
 
-    const uri = vscode.Uri.file(ghqRoot + '/' + selectedRepository);
+    const commandOutput = childProcess.spawnSync('ghq', ['list', '--exact', '--full-path', selectedRepository]).stdout.toString();
+    const repositoryPath = commandOutput.split(/\r?\n/)[0];
+    const uri = vscode.Uri.file(repositoryPath);
     if (fs.existsSync(uri.fsPath)) return uri;
 }
 


### PR DESCRIPTION
It is possible to specify multiple paths ​​for `ghq.root`.

For example, `.gitconfig` is as follows:

```gitconfig
[ghq]
    root = ~/rootB
    root = ~/rootA
```

and then there is `repoA` & `repoB` as below.

```
~
├── rootA
│  └── repoA
└── rootB
   └── repoB
```

In this case, the result of `ghq` command is

```sh
$ ghq root
(home)/rootA

$ ghq root --all
(home)/rootA
(home)/rootB

$ ghq list
repoA
repoB
```

So, we cannot currently open `repoB` from `GHQ: Open Repository`.

I solved this problem by using `ghq list --exact --full-path`.